### PR TITLE
fix font ScanningBox Completion

### DIFF
--- a/src/components/ScanningBox/ScanningBox.css
+++ b/src/components/ScanningBox/ScanningBox.css
@@ -13,7 +13,7 @@
 
 .scanningbox__text {
   margin: 0 auto;
-  font-family: YandexSansText-Bold;
+  font-family: YandexSansDisplay-Bold;
   line-height: 68px;
   font-size: 56px;
   color: #212121;
@@ -21,7 +21,7 @@
 
 .scanningbox__text-accent {
   margin: 0 auto 0 12px;
-  font-family: YandexSansText-Bold;
+  font-family: YandexSansDisplay-Bold;
   line-height: 68px;
   font-size: 56px;
   color: #fefefe;

--- a/src/components/Сompletion/Сompletion.css
+++ b/src/components/Сompletion/Сompletion.css
@@ -17,14 +17,14 @@
 
 .completion__header {
   margin: 67px auto 16px auto;
-  font-family: YandexSansText-Bold;
+  font-family: YandexSansDisplay-Bold;
   line-height: 68px;
   font-size: 56px;
 }
 
 .completion__text {
   margin: 0 auto;
-  font-family: YandexSansText-Regular;
+  font-family: YandexSansDisplay-Regular;
   line-height: 32px;
   font-size: 28px;
 }


### PR DESCRIPTION
Поправила шрифты для компонентов Сompletion и ScanningBox. В компонентах был назначен шрифт YandexSansText, изменила на YandexSansDisplay, в соответствии с макетом.